### PR TITLE
Support Display Common Files inside Boardless

### DIFF
--- a/Boardless/Assets/OBJImport.meta
+++ b/Boardless/Assets/OBJImport.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b84f7d720fe24970981257acd065005
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/CharWordReader.cs
+++ b/Boardless/Assets/OBJImport/CharWordReader.cs
@@ -1,0 +1,183 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.IO;
+using System.Text;
+
+namespace Dummiesman {
+	public class CharWordReader {
+		public char[] word;
+		public int wordSize;
+		public bool endReached;
+
+		private StreamReader reader;
+		private int bufferSize;
+		private char[] buffer;
+		
+		public char currentChar;
+		private int currentPosition = 0;
+		private int maxPosition = 0;
+
+		public CharWordReader(StreamReader reader, int bufferSize) {
+			this.reader = reader;
+			this.bufferSize = bufferSize;
+
+			this.buffer = new char[this.bufferSize];
+			this.word = new char[this.bufferSize];
+
+			this.MoveNext();
+		}
+
+		public void SkipWhitespaces() {
+			while (char.IsWhiteSpace(this.currentChar)) {
+				this.MoveNext();
+			}
+		}
+
+		public void SkipWhitespaces(out bool newLinePassed) {
+			newLinePassed = false;
+			while (char.IsWhiteSpace(this.currentChar)) {
+				if (this.currentChar == '\r' || this.currentChar == '\n') {
+					newLinePassed = true;
+				}
+				this.MoveNext();
+			}
+		}
+
+		public void SkipUntilNewLine() {
+			while (this.currentChar != char.MinValue && this.currentChar != '\n' && this.currentChar != '\r') {
+				this.MoveNext();
+			}
+			this.SkipNewLineSymbols();
+		}
+
+		public void ReadUntilWhiteSpace() {
+			this.wordSize = 0;
+			while (this.currentChar != char.MinValue && char.IsWhiteSpace(this.currentChar) == false) {
+				this.word[this.wordSize] = this.currentChar;
+				this.wordSize++;
+				this.MoveNext();
+			}
+		}
+
+		public void ReadUntilNewLine() {
+			this.wordSize = 0;
+			while (this.currentChar != char.MinValue && this.currentChar != '\n' && this.currentChar != '\r') {
+				this.word[this.wordSize] = this.currentChar;
+				this.wordSize++;
+				this.MoveNext();
+			}
+			this.SkipNewLineSymbols();
+		}
+
+		public bool Is(string other) {
+			if (other.Length != this.wordSize) {
+				return false;
+			}
+
+			for (int i=0; i<this.wordSize; i++) {
+				if (this.word[i] != other[i]) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+        public string GetString(int startIndex = 0) {
+            if (startIndex >= this.wordSize - 1) {
+                return string.Empty;
+            }
+            return new string(this.word, startIndex, this.wordSize - startIndex);
+        }
+		
+		public Vector3 ReadVector() {
+			this.SkipWhitespaces();
+			float x = this.ReadFloat();
+			this.SkipWhitespaces();
+			float y = this.ReadFloat();
+			this.SkipWhitespaces(out var newLinePassed);
+			float z = 0f;
+			if (newLinePassed == false) {
+				z = this.ReadFloat();
+			}
+			return new Vector3(x, y, z);
+		}
+
+		public int ReadInt() {
+			int result = 0;
+			bool isNegative = this.currentChar == '-';
+			if (isNegative == true) {
+				this.MoveNext();
+			}
+			
+			while (this.currentChar >= '0' && this.currentChar <= '9') {
+				var digit = this.currentChar - '0';
+				result = result * 10 + digit;
+				this.MoveNext();
+			}
+
+			return (isNegative == true) ? -result : result;
+		}
+
+		public float ReadFloat() {
+			bool isNegative = this.currentChar == '-';
+			if (isNegative) {
+				this.MoveNext();
+			}
+
+			var num = (float)this.ReadInt();
+			if (this.currentChar == '.' || this.currentChar == ',') {
+				this.MoveNext();
+				num +=  this.ReadFloatEnd();
+
+				if (this.currentChar == 'e' || this.currentChar == 'E') {
+					this.MoveNext();
+					var exp = this.ReadInt();
+					num = num * Mathf.Pow(10f, exp);
+				}
+			}
+			if (isNegative == true) {
+				num = -num;
+			}
+
+			return num;
+		}
+
+		private float ReadFloatEnd() {
+			float result = 0f;
+
+			var exp = 0.1f;
+			while (this.currentChar >= '0' && this.currentChar <= '9') {
+				var digit = this.currentChar - '0';
+				result += digit * exp;
+
+				exp *= 0.1f;
+
+				this.MoveNext();
+			}
+
+			return result;
+		}
+
+		private void SkipNewLineSymbols() {
+			while (this.currentChar == '\n' || this.currentChar == '\r') {
+				this.MoveNext();
+			}
+		}
+
+		public void MoveNext() {
+			this.currentPosition++;
+			if (this.currentPosition >= this.maxPosition) {
+				if (this.reader.EndOfStream == true) {
+					this.currentChar = char.MinValue;
+					this.endReached = true;
+					return;
+				}
+
+				this.currentPosition = 0;
+				this.maxPosition = this.reader.Read(this.buffer, 0, this.bufferSize);
+			}
+			this.currentChar = this.buffer[this.currentPosition];
+		}
+	}
+}

--- a/Boardless/Assets/OBJImport/CharWordReader.cs.meta
+++ b/Boardless/Assets/OBJImport/CharWordReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37ed5e34a98d98669ac1a63bf547afa3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/MTLLoader.cs
+++ b/Boardless/Assets/OBJImport/MTLLoader.cs
@@ -1,0 +1,312 @@
+﻿/*
+ * Copyright (c) 2019 Dummiesman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+*/
+
+using Dummiesman;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class MTLLoader {
+    public List<string> SearchPaths = new List<string>() { "%FileName%_Textures", string.Empty};
+
+    private FileInfo _objFileInfo = null;
+
+    /// <summary>
+    /// The texture loading function. Overridable for stream loading purposes.
+    /// </summary>
+    /// <param name="path">The path supplied by the OBJ file, converted to OS path seperation</param>
+    /// <param name="isNormalMap">Whether the loader is requesting we convert this into a normal map</param>
+    /// <returns>Texture2D if found, or NULL if missing</returns>
+    public virtual Texture2D TextureLoadFunction(string path, bool isNormalMap)
+    {
+        //find it
+        foreach (var searchPath in SearchPaths)
+        {
+            //replace varaibles and combine path
+            string processedPath = (_objFileInfo != null) ? searchPath.Replace("%FileName%", Path.GetFileNameWithoutExtension(_objFileInfo.Name)) 
+                                                          : searchPath;
+            string filePath = Path.Combine(processedPath, path);
+
+            //return if eists
+            if (File.Exists(filePath))
+            {
+                var tex = ImageLoader.LoadTexture(filePath);
+
+                if(isNormalMap)
+                    tex = ImageUtils.ConvertToNormalMap(tex);
+
+                return tex;
+            }
+        }
+
+        //not found
+        return null;
+    }
+
+    private Texture2D TryLoadTexture(string texturePath, bool normalMap = false)
+    {
+        //swap directory seperator char
+        texturePath = texturePath.Replace('\\', Path.DirectorySeparatorChar);
+        texturePath = texturePath.Replace('/', Path.DirectorySeparatorChar);
+
+        return TextureLoadFunction(texturePath, normalMap);
+    }
+    
+    private int GetArgValueCount(string arg)
+    {
+        switch (arg)
+        {
+            case "-bm":
+            case "-clamp":
+            case "-blendu":
+            case "-blendv":
+            case "-imfchan":
+            case "-texres":
+                return 1;
+            case "-mm":
+                return 2;
+            case "-o":
+            case "-s":
+            case "-t":
+                return 3;
+        }
+        return -1;
+    }
+
+    private int GetTexNameIndex(string[] components)
+    {
+        for(int i=1; i < components.Length; i++)
+        {
+            var cmpSkip = GetArgValueCount(components[i]);
+            if(cmpSkip < 0)
+            {
+                return i;
+            }
+            i += cmpSkip;
+        }
+        return -1;
+    }
+
+    private float GetArgValue(string[] components, string arg, float fallback = 1f)
+    {
+        string argLower = arg.ToLower();
+        for(int i=1; i < components.Length - 1; i++)
+        {
+            var cmp = components[i].ToLower();
+            if(argLower == cmp)
+            {
+                return OBJLoaderHelper.FastFloatParse(components[i+1]);
+            }
+        }
+        return fallback;
+    }
+
+    private string GetTexPathFromMapStatement(string processedLine, string[] splitLine)
+    {
+        int texNameCmpIdx = GetTexNameIndex(splitLine);
+        if(texNameCmpIdx < 0)
+        {
+            Debug.LogError($"texNameCmpIdx < 0 on line {processedLine}. Texture not loaded.");
+            return null;
+        }
+
+        int texNameIdx = processedLine.IndexOf(splitLine[texNameCmpIdx]);
+        string texturePath = processedLine.Substring(texNameIdx);
+
+        return texturePath;
+    }
+
+    /// <summary>
+    /// Loads a *.mtl file
+    /// </summary>
+    /// <param name="input">The input stream from the MTL file</param>
+    /// <returns>Dictionary containing loaded materials</returns>
+    public Dictionary<string, Material> Load(Stream input)
+    {
+        var inputReader = new StreamReader(input);
+        var reader = new StringReader(inputReader.ReadToEnd());
+
+        Dictionary<string, Material> mtlDict = new Dictionary<string, Material>();
+        Material currentMaterial = null;
+
+        for (string line = reader.ReadLine(); line != null; line = reader.ReadLine())
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            string processedLine = line.Clean();
+            string[] splitLine = processedLine.Split(' ');
+
+            //blank or comment
+            if (splitLine.Length < 2 || processedLine[0] == '#')
+                continue;
+
+            //newmtl
+            if (splitLine[0] == "newmtl")
+            {
+                string materialName = processedLine.Substring(7);
+                Shader shader = Shader.Find("Standard (Specular setup)");
+                if (shader == null)
+                {
+                    Debug.LogError("Shader not found: Standard (Specular setup)");
+                    continue;
+                }
+                var newMtl = new Material(shader) { name = materialName };
+                mtlDict[materialName] = newMtl;
+                currentMaterial = newMtl;
+
+                continue;
+            }
+
+            //anything past here requires a material instance
+            if (currentMaterial == null)
+                continue;
+
+            //diffuse color
+            if (splitLine[0] == "Kd" || splitLine[0] == "kd")
+            {
+                var currentColor = currentMaterial.GetColor("_Color");
+                var kdColor = OBJLoaderHelper.ColorFromStrArray(splitLine);
+
+                currentMaterial.SetColor("_Color", new Color(kdColor.r, kdColor.g, kdColor.b, currentColor.a));
+                continue;
+            }
+
+            //diffuse map
+            if (splitLine[0] == "map_Kd" || splitLine[0] == "map_kd")
+            {
+                string texturePath = GetTexPathFromMapStatement(processedLine, splitLine);
+                if(texturePath == null)
+                {
+                    continue; //invalid args or sth
+                }
+
+                var KdTexture = TryLoadTexture(texturePath);
+                currentMaterial.SetTexture("_MainTex", KdTexture);
+
+                //set transparent mode if the texture has transparency
+                if(KdTexture != null && (KdTexture.format == TextureFormat.DXT5 || KdTexture.format == TextureFormat.ARGB32))
+                {
+                    OBJLoaderHelper.EnableMaterialTransparency(currentMaterial);
+                }
+
+                //flip texture if this is a dds
+                if(Path.GetExtension(texturePath).ToLower() == ".dds")
+                {
+                    currentMaterial.mainTextureScale = new Vector2(1f, -1f);
+                }
+
+                continue;
+            }
+
+            //bump map
+            if (splitLine[0] == "map_Bump" || splitLine[0] == "map_bump")
+            {
+                string texturePath = GetTexPathFromMapStatement(processedLine, splitLine);
+                if(texturePath == null)
+                {
+                    continue; //invalid args or sth
+                }
+
+                var bumpTexture = TryLoadTexture(texturePath, true);
+                float bumpScale = GetArgValue(splitLine, "-bm", 1.0f);
+
+                if (bumpTexture != null) {
+                    currentMaterial.SetTexture("_BumpMap", bumpTexture);
+                    currentMaterial.SetFloat("_BumpScale", bumpScale);
+                    currentMaterial.EnableKeyword("_NORMALMAP");
+                }
+
+                continue;
+            }
+
+            //specular color
+            if (splitLine[0] == "Ks" || splitLine[0] == "ks")
+            {
+                currentMaterial.SetColor("_SpecColor", OBJLoaderHelper.ColorFromStrArray(splitLine));
+                continue;
+            }
+
+            //emission color
+            if (splitLine[0] == "Ka" || splitLine[0] == "ka")
+            {
+                currentMaterial.SetColor("_EmissionColor", OBJLoaderHelper.ColorFromStrArray(splitLine, 0.05f));
+                currentMaterial.EnableKeyword("_EMISSION");
+                continue;
+            }
+
+            //emission map
+            if (splitLine[0] == "map_Ka" || splitLine[0] == "map_ka")
+            {
+                string texturePath = GetTexPathFromMapStatement(processedLine, splitLine);
+                if(texturePath == null)
+                {
+                    continue; //invalid args or sth
+                }
+
+                currentMaterial.SetTexture("_EmissionMap", TryLoadTexture(texturePath));
+                continue;
+            }
+
+            //alpha
+            if (splitLine[0] == "d" || splitLine[0] == "Tr")
+            {
+                float visibility = OBJLoaderHelper.FastFloatParse(splitLine[1]);
+                
+                //tr statement is just d inverted
+                if(splitLine[0] == "Tr")
+                    visibility = 1f - visibility;  
+
+                if(visibility < (1f - Mathf.Epsilon))
+                {
+                    var currentColor = currentMaterial.GetColor("_Color");
+
+                    currentColor.a = visibility;
+                    currentMaterial.SetColor("_Color", currentColor);
+
+                    OBJLoaderHelper.EnableMaterialTransparency(currentMaterial);
+                }
+                continue;
+            }
+
+            //glossiness
+            if (splitLine[0] == "Ns" || splitLine[0] == "ns")
+            {
+                float Ns = OBJLoaderHelper.FastFloatParse(splitLine[1]);
+                Ns = (Ns / 1000f);
+                currentMaterial.SetFloat("_Glossiness", Ns);
+            }
+        }
+
+        //return our dict
+        return mtlDict;
+    }
+
+    /// <summary>
+    /// Loads a *.mtl file
+    /// </summary>
+    /// <param name="path">The path to the MTL file</param>
+    /// <returns>Dictionary containing loaded materials</returns>
+	public Dictionary<string, Material> Load(string path)
+    {
+        _objFileInfo = new FileInfo(path); //get file info
+        SearchPaths.Add(_objFileInfo.Directory.FullName); //add root path to search dir
+
+        using (var fs = new FileStream(path, FileMode.Open))
+        {
+            return Load(fs); //actually load
+        }
+        
+    }
+}

--- a/Boardless/Assets/OBJImport/MTLLoader.cs.meta
+++ b/Boardless/Assets/OBJImport/MTLLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11b3883c0720fb8409b86b54877b58ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/OBJLoader.cs
+++ b/Boardless/Assets/OBJImport/OBJLoader.cs
@@ -1,0 +1,333 @@
+﻿/*
+ * Copyright (c) 2019 Dummiesman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+*/
+
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using System;
+using Dummiesman;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Dummiesman
+{
+    public enum SplitMode {
+        None,
+        Object,
+        Material
+    }
+    
+    public class OBJLoader
+    {
+        //options
+        /// <summary>
+        /// Determines how objects will be created
+        /// </summary>
+        public SplitMode SplitMode = SplitMode.Object;
+
+        //global lists, accessed by objobjectbuilder
+        internal List<Vector3> Vertices = new List<Vector3>();
+        internal List<Vector3> Normals = new List<Vector3>();
+        internal List<Vector2> UVs = new List<Vector2>();
+
+        //materials, accessed by objobjectbuilder
+        internal Dictionary<string, Material> Materials;
+
+        //file info for files loaded from file path, used for GameObject naming and MTL finding
+        private FileInfo _objInfo;
+
+#if UNITY_EDITOR
+        [MenuItem("GameObject/Import From OBJ")]
+        static void ObjLoadMenu()
+        {
+            string pth =  EditorUtility.OpenFilePanel("Import OBJ", "", "obj");
+            if (!string.IsNullOrEmpty(pth))
+            {
+                System.Diagnostics.Stopwatch s = new System.Diagnostics.Stopwatch();
+                s.Start();
+
+                var loader = new OBJLoader
+                {
+                    SplitMode = SplitMode.Object,
+                };
+                loader.Load(pth);
+
+                Debug.Log($"OBJ import time: {s.ElapsedMilliseconds}ms");
+                s.Stop();
+            }
+        }
+#endif
+
+        /// <summary>
+        /// Helper function to load mtllib statements
+        /// </summary>
+        /// <param name="mtlLibPath"></param>
+        private void LoadMaterialLibrary(string mtlLibPath)
+        {
+            if (_objInfo != null)
+            {
+                if (File.Exists(Path.Combine(_objInfo.Directory.FullName, mtlLibPath)))
+                {
+                    Materials = new MTLLoader().Load(Path.Combine(_objInfo.Directory.FullName, mtlLibPath));
+                    return;
+                }
+            }
+
+            if (File.Exists(mtlLibPath))
+            {
+                Materials = new MTLLoader().Load(mtlLibPath);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Load an OBJ file from a stream. No materials will be loaded, and will instead be supplemented by a blank white material.
+        /// </summary>
+        /// <param name="input">Input OBJ stream</param>
+        /// <returns>Returns a GameObject represeting the OBJ file, with each imported object as a child.</returns>
+        public GameObject Load(Stream input)
+        {
+            var reader = new StreamReader(input);
+            //var reader = new StringReader(inputReader.ReadToEnd());
+
+            Dictionary<string, OBJObjectBuilder> builderDict = new Dictionary<string, OBJObjectBuilder>();
+            OBJObjectBuilder currentBuilder = null;
+            string currentMaterial = "default";
+
+            //lists for face data
+            //prevents excess GC
+            List<int> vertexIndices = new List<int>();
+            List<int> normalIndices = new List<int>();
+            List<int> uvIndices = new List<int>();
+
+            //helper func
+            Action<string> setCurrentObjectFunc = (string objectName) =>
+            {
+                if (!builderDict.TryGetValue(objectName, out currentBuilder))
+                {
+                    currentBuilder = new OBJObjectBuilder(objectName, this);
+                    builderDict[objectName] = currentBuilder;
+                }
+            };
+
+            //create default object
+            setCurrentObjectFunc.Invoke("default");
+
+			//var buffer = new DoubleBuffer(reader, 256 * 1024);
+			var buffer = new CharWordReader(reader, 4 * 1024);
+
+			//do the reading
+			while (true)
+            {
+				buffer.SkipWhitespaces();
+
+				if (buffer.endReached == true) {
+					break;
+				}
+
+				buffer.ReadUntilWhiteSpace();
+				
+                //comment or blank
+                if (buffer.Is("#"))
+                {
+					buffer.SkipUntilNewLine();
+                    continue;
+                }
+				
+				if (Materials == null && buffer.Is("mtllib")) {
+					buffer.SkipWhitespaces();
+					buffer.ReadUntilNewLine();
+					string mtlLibPath = buffer.GetString();
+					LoadMaterialLibrary(mtlLibPath);
+					continue;
+				}
+				
+				if (buffer.Is("v")) {
+					Vertices.Add(buffer.ReadVector());
+					continue;
+				}
+
+				//normal
+				if (buffer.Is("vn")) {
+                    Normals.Add(buffer.ReadVector());
+                    continue;
+                }
+
+                //uv
+				if (buffer.Is("vt")) {
+                    UVs.Add(buffer.ReadVector());
+                    continue;
+                }
+
+                //new material
+				if (buffer.Is("usemtl")) {
+					buffer.SkipWhitespaces();
+					buffer.ReadUntilNewLine();
+					string materialName = buffer.GetString();
+                    currentMaterial = materialName;
+
+                    if(SplitMode == SplitMode.Material)
+                    {
+                        setCurrentObjectFunc.Invoke(materialName);
+                    }
+                    continue;
+                }
+
+                //new object
+                if ((buffer.Is("o") || buffer.Is("g")) && SplitMode == SplitMode.Object) {
+                    buffer.ReadUntilNewLine();
+                    string objectName = buffer.GetString(1);
+                    setCurrentObjectFunc.Invoke(objectName);
+                    continue;
+                }
+
+                //face data (the fun part)
+                if (buffer.Is("f"))
+                {
+                    //loop through indices
+                    while (true)
+                    {
+						bool newLinePassed;
+						buffer.SkipWhitespaces(out newLinePassed);
+						if (newLinePassed == true) {
+							break;
+						}
+
+                        int vertexIndex = int.MinValue;
+                        int normalIndex = int.MinValue;
+                        int uvIndex = int.MinValue;
+
+						vertexIndex = buffer.ReadInt();
+						if (buffer.currentChar == '/') {
+							buffer.MoveNext();
+							if (buffer.currentChar != '/') {
+								uvIndex = buffer.ReadInt();
+							}
+							if (buffer.currentChar == '/') {
+								buffer.MoveNext();
+								normalIndex = buffer.ReadInt();
+							}
+						}
+
+                        //"postprocess" indices
+                        if (vertexIndex > int.MinValue)
+                        {
+                            if (vertexIndex < 0)
+                                vertexIndex = Vertices.Count - vertexIndex;
+                            vertexIndex--;
+                        }
+                        if (normalIndex > int.MinValue)
+                        {
+                            if (normalIndex < 0)
+                                normalIndex = Normals.Count - normalIndex;
+                            normalIndex--;
+                        }
+                        if (uvIndex > int.MinValue)
+                        {
+                            if (uvIndex < 0)
+                                uvIndex = UVs.Count - uvIndex;
+                            uvIndex--;
+                        }
+
+                        //set array values
+                        vertexIndices.Add(vertexIndex);
+                        normalIndices.Add(normalIndex);
+                        uvIndices.Add(uvIndex);
+                    }
+
+                    //push to builder
+                    currentBuilder.PushFace(currentMaterial, vertexIndices, normalIndices, uvIndices);
+
+                    //clear lists
+                    vertexIndices.Clear();
+                    normalIndices.Clear();
+                    uvIndices.Clear();
+
+					continue;
+                }
+
+				buffer.SkipUntilNewLine();
+            }
+
+            //finally, put it all together
+            GameObject obj = new GameObject(_objInfo != null ? Path.GetFileNameWithoutExtension(_objInfo.Name) : "WavefrontObject");
+            obj.transform.localScale = new Vector3(-1f, 1f, 1f);
+
+            foreach (var builder in builderDict)
+            {
+                //empty object
+                if (builder.Value.PushedFaceCount == 0)
+                    continue;
+
+                var builtObj = builder.Value.Build();
+                builtObj.transform.SetParent(obj.transform, false);
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Load an OBJ and MTL file from a stream.
+        /// </summary>
+        /// <param name="input">Input OBJ stream</param>
+        /// /// <param name="mtlInput">Input MTL stream</param>
+        /// <returns>Returns a GameObject represeting the OBJ file, with each imported object as a child.</returns>
+        public GameObject Load(Stream input, Stream mtlInput)
+        {
+            var mtlLoader = new MTLLoader();
+            Materials = mtlLoader.Load(mtlInput);
+
+            return Load(input);
+        }
+
+        /// <summary>
+        /// Load an OBJ and MTL file from a file path.
+        /// </summary>
+        /// <param name="path">Input OBJ path</param>
+        /// /// <param name="mtlPath">Input MTL path</param>
+        /// <returns>Returns a GameObject represeting the OBJ file, with each imported object as a child.</returns>
+        public GameObject Load(string path, string mtlPath)
+        {
+            _objInfo = new FileInfo(path);
+            if (!string.IsNullOrEmpty(mtlPath) && File.Exists(mtlPath))
+            {
+                var mtlLoader = new MTLLoader();
+                Materials = mtlLoader.Load(mtlPath);
+
+                using (var fs = new FileStream(path, FileMode.Open))
+                {
+                    return Load(fs);
+                }
+            }
+            else
+            {
+                using (var fs = new FileStream(path, FileMode.Open))
+                {
+                    return Load(fs);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Load an OBJ file from a file path. This function will also attempt to load the MTL defined in the OBJ file.
+        /// </summary>
+        /// <param name="path">Input OBJ path</param>
+        /// <returns>Returns a GameObject represeting the OBJ file, with each imported object as a child.</returns>
+        public GameObject Load(string path)
+        {
+            return Load(path, null);
+        }
+    }
+}

--- a/Boardless/Assets/OBJImport/OBJLoader.cs.meta
+++ b/Boardless/Assets/OBJImport/OBJLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9951190d0789ee64599dc374c1f81ce5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/OBJLoaderHelper.cs
+++ b/Boardless/Assets/OBJImport/OBJLoaderHelper.cs
@@ -1,0 +1,103 @@
+﻿using System.Globalization;
+using UnityEngine;
+
+namespace Dummiesman 
+{
+    public static class OBJLoaderHelper  
+    {
+        /// <summary>
+        /// Enables transparency mode on standard materials
+        /// </summary>
+        public static void EnableMaterialTransparency(Material mtl)
+        {
+            mtl.SetFloat("_Mode", 3f);
+            mtl.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+            mtl.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            mtl.SetInt("_ZWrite", 0);
+            mtl.DisableKeyword("_ALPHATEST_ON");
+            mtl.EnableKeyword("_ALPHABLEND_ON");
+            mtl.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+            mtl.renderQueue = 3000;
+        }
+
+        /// <summary>
+        /// Modified from https://codereview.stackexchange.com/a/76891. Faster than float.Parse
+        /// </summary>
+        public static float FastFloatParse(string input)
+        {
+            if (input.Contains("e") || input.Contains("E"))
+                return float.Parse(input, CultureInfo.InvariantCulture);
+
+            float result = 0;
+            int pos = 0;
+            int len = input.Length;
+
+            if (len == 0) return float.NaN;
+            char c = input[0];
+            float sign = 1;
+            if (c == '-')
+            {
+                sign = -1;
+                ++pos;
+                if (pos >= len) return float.NaN;
+            }
+
+            while (true) // breaks inside on pos >= len or non-digit character
+            {
+                if (pos >= len) return sign * result;
+                c = input[pos++];
+                if (c < '0' || c > '9') break;
+                result = (result * 10.0f) + (c - '0');
+            }
+
+            if (c != '.' && c != ',') return float.NaN;
+            float exp = 0.1f;
+            while (pos < len)
+            {
+                c = input[pos++];
+                if (c < '0' || c > '9') return float.NaN;
+                result += (c - '0') * exp;
+                exp *= 0.1f;
+            }
+            return sign * result;
+        }
+
+        /// <summary>
+        /// Modified from http://cc.davelozinski.com/c-sharp/fastest-way-to-convert-a-string-to-an-int. Faster than int.Parse
+        /// </summary>
+        public static int FastIntParse(string input)
+        {
+            int result = 0;
+            bool isNegative = (input[0] == '-');
+            
+            for (int i = (isNegative) ? 1 : 0; i < input.Length; i++)
+                result = result * 10 + (input[i] - '0');
+            return (isNegative) ? -result : result;
+        }
+
+        public static Material CreateNullMaterial()
+        {
+            return new Material(Shader.Find("Standard (Specular setup)"));
+        }
+
+        public static Vector3 VectorFromStrArray(string[] cmps)
+        {
+            float x = FastFloatParse(cmps[1]);
+            float y = FastFloatParse(cmps[2]);
+            if (cmps.Length == 4)
+            {
+                float z = FastFloatParse(cmps[3]);
+                return new Vector3(x, y, z);
+            }
+            return new Vector2(x, y);
+        }
+
+        public static Color ColorFromStrArray(string[] cmps, float scalar = 1.0f)
+        {
+            float Kr = FastFloatParse(cmps[1]) * scalar;
+            float Kg = FastFloatParse(cmps[2]) * scalar;
+            float Kb = FastFloatParse(cmps[3]) * scalar;
+            return new Color(Kr, Kg, Kb);
+        }
+    }
+}

--- a/Boardless/Assets/OBJImport/OBJLoaderHelper.cs.meta
+++ b/Boardless/Assets/OBJImport/OBJLoaderHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6083f989375f6104aafb31a9e82ee153
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/OBJObjectBuilder.cs
+++ b/Boardless/Assets/OBJImport/OBJObjectBuilder.cs
@@ -1,0 +1,200 @@
+﻿/*
+ * Copyright (c) 2019 Dummiesman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+*/
+
+using Dummiesman;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Dummiesman {
+public class OBJObjectBuilder {
+	//
+	public int PushedFaceCount { get; private set; } = 0;
+
+	//stuff passed in by ctor
+	private OBJLoader _loader;
+	private string _name;
+
+	private Dictionary<ObjLoopHash, int> _globalIndexRemap = new Dictionary<ObjLoopHash, int>();
+	private Dictionary<string, List<int>> _materialIndices = new Dictionary<string, List<int>>();
+	private List<int> _currentIndexList;
+	private string _lastMaterial = null;
+
+	//our local vert/normal/uv
+	private List<Vector3> _vertices = new List<Vector3>();
+	private List<Vector3> _normals = new List<Vector3>();
+	private List<Vector2> _uvs = new List<Vector2>();
+
+	//this will be set if the model has no normals or missing normal info
+	private bool recalculateNormals = false;
+
+	/// <summary>
+	/// Loop hasher helper class
+	/// </summary>
+	private class ObjLoopHash {
+		public int vertexIndex;
+		public int normalIndex;
+		public int uvIndex;
+
+		public override bool Equals(object obj) {
+			if (!(obj is ObjLoopHash))
+				return false;
+
+			var hash = obj as ObjLoopHash;
+			return (hash.vertexIndex == vertexIndex) && (hash.uvIndex == uvIndex) && (hash.normalIndex == normalIndex);
+		}
+
+		public override int GetHashCode() {
+			int hc = 3;
+			hc = unchecked(hc * 314159 + vertexIndex);
+			hc = unchecked(hc * 314159 + normalIndex);
+			hc = unchecked(hc * 314159 + uvIndex);
+			return hc;
+		}
+	}
+
+	public GameObject Build() {
+		var go = new GameObject(_name);
+
+		//add meshrenderer
+		var mr = go.AddComponent<MeshRenderer>();
+		int submesh = 0;
+
+
+		//locate the material for each submesh
+		Material[] materialArray = new Material[_materialIndices.Count];
+		foreach (var kvp in _materialIndices) {
+			Material material = null;
+			if (_loader.Materials == null) {
+				material = OBJLoaderHelper.CreateNullMaterial();
+				material.name = kvp.Key;
+			} else {
+				if (!_loader.Materials.TryGetValue(kvp.Key, out material)) {
+					material = OBJLoaderHelper.CreateNullMaterial();
+					material.name = kvp.Key;
+					_loader.Materials[kvp.Key] = material;
+				}
+			}
+			materialArray[submesh] = material;
+			submesh++;
+		}
+		mr.sharedMaterials = materialArray;
+
+		//add meshfilter
+		var mf = go.AddComponent<MeshFilter>();
+		submesh = 0;
+
+		var msh = new Mesh() {
+			name = _name, 
+			indexFormat = (_vertices.Count > 65535) ? UnityEngine.Rendering.IndexFormat.UInt32 : UnityEngine.Rendering.IndexFormat.UInt16,
+			subMeshCount = _materialIndices.Count 
+		};
+
+		//set vertex data
+		msh.SetVertices(_vertices);
+		msh.SetNormals(_normals);
+		msh.SetUVs(0, _uvs);
+
+		//set faces
+		foreach (var kvp in _materialIndices) {
+			msh.SetTriangles(kvp.Value, submesh);
+			submesh++;
+		}
+
+		//recalculations
+		if (recalculateNormals)
+			msh.RecalculateNormals();
+		msh.RecalculateTangents();
+		msh.RecalculateBounds();
+
+		mf.sharedMesh = msh;
+
+		//
+		return go;
+	}
+
+    public void SetMaterial(string name) {
+		if (!_materialIndices.TryGetValue(name, out _currentIndexList))
+		{
+			_currentIndexList = new List<int>();
+			_materialIndices[name] = _currentIndexList;
+		}
+	}
+
+
+	public void PushFace(string material, List<int> vertexIndices, List<int> normalIndices, List<int> uvIndices) {
+		//invalid face size?
+		if (vertexIndices.Count < 3) {
+			return;
+		}
+
+		//set material
+		if (material != _lastMaterial) {
+			SetMaterial(material);
+			_lastMaterial = material;
+		}
+
+		//remap
+		int[] indexRemap = new int[vertexIndices.Count];
+		for (int i = 0; i < vertexIndices.Count; i++) {
+			int vertexIndex = vertexIndices[i];
+			int normalIndex = normalIndices[i];
+			int uvIndex = uvIndices[i];
+
+			var hashObj = new ObjLoopHash() {
+				vertexIndex = vertexIndex,
+				normalIndex = normalIndex,
+				uvIndex = uvIndex
+			};
+			int remap = -1;
+
+			if (!_globalIndexRemap.TryGetValue(hashObj, out remap)) {
+				//add to dict
+				_globalIndexRemap.Add(hashObj, _vertices.Count);
+				remap = _vertices.Count;
+
+				//add new verts and what not
+				_vertices.Add((vertexIndex >= 0 && vertexIndex < _loader.Vertices.Count) ? _loader.Vertices[vertexIndex] : Vector3.zero);
+				_normals.Add((normalIndex >= 0 && normalIndex < _loader.Normals.Count) ? _loader.Normals[normalIndex] : Vector3.zero);
+				_uvs.Add((uvIndex >= 0 && uvIndex < _loader.UVs.Count) ? _loader.UVs[uvIndex] : Vector2.zero);
+
+				//mark recalc flag
+				if (normalIndex < 0)
+					recalculateNormals = true;
+			}
+
+			indexRemap[i] = remap;
+		}
+
+
+		//add face to our mesh list
+		if (indexRemap.Length == 3) {
+			_currentIndexList.AddRange(new int[] { indexRemap[0], indexRemap[1], indexRemap[2] });
+		} else if (indexRemap.Length == 4) {
+			_currentIndexList.AddRange(new int[] { indexRemap[0], indexRemap[1], indexRemap[2] });
+			_currentIndexList.AddRange(new int[] { indexRemap[2], indexRemap[3], indexRemap[0] });
+		} else if (indexRemap.Length > 4) {
+			for (int i = indexRemap.Length - 1; i >= 2; i--) {
+				_currentIndexList.AddRange(new int[] { indexRemap[0], indexRemap[i - 1], indexRemap[i] });
+			}
+		}
+
+		PushedFaceCount++;
+	}
+
+	public OBJObjectBuilder(string name, OBJLoader loader) {
+		_name = name;
+		_loader = loader;
+	}
+}
+}

--- a/Boardless/Assets/OBJImport/OBJObjectBuilder.cs.meta
+++ b/Boardless/Assets/OBJImport/OBJObjectBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8242329223027ef40a531fc4dc2efd1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/README.HTML
+++ b/Boardless/Assets/OBJImport/README.HTML
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Dummiesman OBJ Importer Readme</title>
+</head>
+
+<body>
+    <h2>Dummiesman's OBJ Importer</h2>
+    <p>Works during runtime*, and in editor! A couple of code samples are provided in the Samples folder.</p>
+    <br />
+    <h2>*Runtime Import Note</h2>
+    <p>You must go to the "Graphics" tab in your project, and add "Standard (Specular Setup)" to the always included shaders. This will make your next build take a while.</p>
+    <br />
+    <h2>Features</h2>
+    <ul>
+        <li>Material file loading</li>
+        <li>Runtime texture library supporting BMP, TGA, JPG, PNG, DDS, and CRN textures.</li>
+        <li>Decent import speed (~750k triangles in about 10 seconds)</li>
+        <li>Support for loading obj and mtl from stream, as well as overridable callback for texture loads</li>
+        <li>Works in editor, and during runtime</li>
+        <li>Loads triangles, quads, and ngons</li>
+    </ul>
+</body>
+
+</html>

--- a/Boardless/Assets/OBJImport/README.HTML.meta
+++ b/Boardless/Assets/OBJImport/README.HTML.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
-guid: 7c8e0d280c24c4aba81a4294e87548ec
-NativeFormatImporter:
+guid: 127e58e7a0d489046a128e511967dea8
+TextScriptImporter:
   externalObjects: {}
-  mainObjectFileID: 25800000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/Samples.meta
+++ b/Boardless/Assets/OBJImport/Samples.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e292531b556307479437e7763c8b31f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/StringExtensions.cs
+++ b/Boardless/Assets/OBJImport/StringExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace Dummiesman
+{
+    public static class StringExtensions
+    {
+        public static string Clean(this string str)
+        {
+            string rstr = str.Replace('\t', ' ');
+            while (rstr.Contains("  "))
+                rstr = rstr.Replace("  ", " ");
+            return rstr.Trim();
+        }
+    }
+}

--- a/Boardless/Assets/OBJImport/StringExtensions.cs.meta
+++ b/Boardless/Assets/OBJImport/StringExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ef7489c6f646f4448ffe979ea9857da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/TextureLoader.meta
+++ b/Boardless/Assets/OBJImport/TextureLoader.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce592b27d670b994b8150b9ddd9fa341
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/TextureLoader/BMPLoader.cs
+++ b/Boardless/Assets/OBJImport/TextureLoader/BMPLoader.cs
@@ -1,0 +1,560 @@
+﻿#region License and Information
+/*****
+*
+* BMPLoader.cs
+* 
+* This is a simple implementation of a BMP file loader for Unity3D.
+* Formats it should support are:
+*  - 1 bit monochrome indexed
+*  - 2-8 bit indexed
+*  - 16 / 24 / 32 bit color (including "BI_BITFIELDS")
+*  - RLE-4 and RLE-8 support has been added.
+* 
+* Unless the type is "BI_ALPHABITFIELDS" the loader does not interpret alpha
+* values by default, however you can set the "ReadPaletteAlpha" setting to
+* true to interpret the 4th (usually "00") value as alpha for indexed images.
+* You can also set "ForceAlphaReadWhenPossible" to true so it will interpret
+* the "left over" bits as alpha if there are any. It will also force to read
+* alpha from a palette if it's an indexed image, just like "ReadPaletteAlpha".
+* 
+* It's not tested well to the bone, so there might be some errors somewhere.
+* However I tested it with 4 different images created with MS Paint
+* (1bit, 4bit, 8bit, 24bit) as those are the only formats supported.
+* 
+* 2017.02.05 - first version 
+* 2017.03.06 - Added RLE4 / RLE8 support
+* 
+* Copyright (c) 2017 Markus Göbel (Bunny83)
+* 
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to
+* deal in the Software without restriction, including without limitation the
+* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+* sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+* 
+*****/
+#endregion License and Information
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System;
+
+namespace B83.Image.BMP
+{
+    public enum BMPComressionMode : int
+    {
+        BI_RGB = 0x00,
+        BI_RLE8 = 0x01,
+        BI_RLE4 = 0x02,
+        BI_BITFIELDS = 0x03,
+        BI_JPEG = 0x04,
+        BI_PNG = 0x05,
+        BI_ALPHABITFIELDS = 0x06,
+
+        BI_CMYK = 0x0B,
+        BI_CMYKRLE8 = 0x0C,
+        BI_CMYKRLE4 = 0x0D,
+
+    }
+    public struct BMPFileHeader
+    {
+        public ushort magic; // "BM"
+        public uint filesize;
+        public uint reserved;
+        public uint offset;
+    }
+    public struct BitmapInfoHeader
+    {
+        public uint size;
+        public int width;
+        public int height;
+        public ushort nColorPlanes; // always 1
+        public ushort nBitsPerPixel; // [1,4,8,16,24,32]
+        public BMPComressionMode compressionMethod;
+        public uint rawImageSize; // can be "0"
+        public int xPPM;
+        public int yPPM;
+        public uint nPaletteColors;
+        public uint nImportantColors;
+
+        public int absWidth { get { return Mathf.Abs(width); } }
+        public int absHeight { get { return Mathf.Abs(height); } }
+
+    }
+
+    public class BMPImage
+    {
+        public BMPFileHeader header;
+        public BitmapInfoHeader info;
+        public uint rMask = 0x00FF0000;
+        public uint gMask = 0x0000FF00;
+        public uint bMask = 0x000000FF;
+        public uint aMask = 0x00000000;
+        public List<Color32> palette;
+        public Color32[] imageData;
+        public Texture2D ToTexture2D()
+        {
+            var tex = new Texture2D(info.absWidth, info.absHeight);
+            tex.SetPixels32(imageData);
+            tex.Apply();
+            return tex;
+        }
+    }
+
+
+    public class BMPLoader
+    {
+        const ushort MAGIC = 0x4D42; // "BM" little endian
+        public bool ReadPaletteAlpha = false;
+        public bool ForceAlphaReadWhenPossible = false;
+
+        public BMPImage LoadBMP(string aFileName)
+        {
+            using (var file = File.OpenRead(aFileName))
+                return LoadBMP(file);
+        }
+        public BMPImage LoadBMP(byte[] aData)
+        {
+            using (var stream = new MemoryStream(aData))
+                return LoadBMP(stream);
+        }
+
+        public BMPImage LoadBMP(Stream aData)
+        {
+            using (var reader = new BinaryReader(aData))
+                return LoadBMP(reader);
+
+        }
+        public BMPImage LoadBMP(BinaryReader aReader)
+        {
+            BMPImage bmp = new BMPImage();
+            if (!ReadFileHeader(aReader, ref bmp.header))
+            {
+                Debug.LogError("Not a BMP file");
+                return null;
+            }
+            if (!ReadInfoHeader(aReader, ref bmp.info))
+            {
+                Debug.LogError("Unsupported header format");
+                return null;
+            }
+            if (bmp.info.compressionMethod != BMPComressionMode.BI_RGB
+                && bmp.info.compressionMethod != BMPComressionMode.BI_BITFIELDS
+                && bmp.info.compressionMethod != BMPComressionMode.BI_ALPHABITFIELDS
+                && bmp.info.compressionMethod != BMPComressionMode.BI_RLE4
+                && bmp.info.compressionMethod != BMPComressionMode.BI_RLE8
+                )
+            {
+                Debug.LogError("Unsupported image format: " + bmp.info.compressionMethod);
+                return null;
+            }
+            long offset = 14 + bmp.info.size;
+            aReader.BaseStream.Seek(offset, SeekOrigin.Begin);
+            if (bmp.info.nBitsPerPixel < 24)
+            {
+                bmp.rMask = 0x00007C00;
+                bmp.gMask = 0x000003E0;
+                bmp.bMask = 0x0000001F;
+            }
+
+            if (bmp.info.compressionMethod == BMPComressionMode.BI_BITFIELDS || bmp.info.compressionMethod == BMPComressionMode.BI_ALPHABITFIELDS)
+            {
+                bmp.rMask = aReader.ReadUInt32();
+                bmp.gMask = aReader.ReadUInt32();
+                bmp.bMask = aReader.ReadUInt32();
+            }
+            if (ForceAlphaReadWhenPossible)
+                bmp.aMask = GetMask(bmp.info.nBitsPerPixel) ^ (bmp.rMask | bmp.gMask | bmp.bMask);
+
+            if (bmp.info.compressionMethod == BMPComressionMode.BI_ALPHABITFIELDS)
+                bmp.aMask = aReader.ReadUInt32();
+
+            if (bmp.info.nPaletteColors > 0 || bmp.info.nBitsPerPixel <= 8)
+                bmp.palette = ReadPalette(aReader, bmp, ReadPaletteAlpha || ForceAlphaReadWhenPossible);
+
+
+            aReader.BaseStream.Seek(bmp.header.offset, SeekOrigin.Begin);
+            bool uncompressed = bmp.info.compressionMethod == BMPComressionMode.BI_RGB ||
+                bmp.info.compressionMethod == BMPComressionMode.BI_BITFIELDS ||
+                bmp.info.compressionMethod == BMPComressionMode.BI_ALPHABITFIELDS;
+            if (bmp.info.nBitsPerPixel == 32 && uncompressed)
+                Read32BitImage(aReader, bmp);
+            else if (bmp.info.nBitsPerPixel == 24 && uncompressed)
+                Read24BitImage(aReader, bmp);
+            else if (bmp.info.nBitsPerPixel == 16 && uncompressed)
+                Read16BitImage(aReader, bmp);
+            else if (bmp.info.compressionMethod == BMPComressionMode.BI_RLE4 && bmp.info.nBitsPerPixel == 4 && bmp.palette != null)
+                ReadIndexedImageRLE4(aReader, bmp);
+            else if (bmp.info.compressionMethod == BMPComressionMode.BI_RLE8 && bmp.info.nBitsPerPixel == 8 && bmp.palette != null)
+                ReadIndexedImageRLE8(aReader, bmp);
+            else if (uncompressed && bmp.info.nBitsPerPixel <= 8 && bmp.palette != null)
+                ReadIndexedImage(aReader, bmp);
+            else
+            {
+                Debug.LogError("Unsupported file format: " + bmp.info.compressionMethod + " BPP: " + bmp.info.nBitsPerPixel);
+                return null;
+            }
+            return bmp;
+        }
+
+
+        private static void Read32BitImage(BinaryReader aReader, BMPImage bmp)
+        {
+            int w = Mathf.Abs(bmp.info.width);
+            int h = Mathf.Abs(bmp.info.height);
+            Color32[] data = bmp.imageData = new Color32[w * h];
+            if (aReader.BaseStream.Position + w * h * 4 > aReader.BaseStream.Length)
+            {
+                Debug.LogError("Unexpected end of file.");
+                return;
+            }
+            int shiftR = GetShiftCount(bmp.rMask);
+            int shiftG = GetShiftCount(bmp.gMask);
+            int shiftB = GetShiftCount(bmp.bMask);
+            int shiftA = GetShiftCount(bmp.aMask);
+            byte a = 255;
+            for (int i = 0; i < data.Length; i++)
+            {
+                uint v = aReader.ReadUInt32();
+                byte r = (byte)((v & bmp.rMask) >> shiftR);
+                byte g = (byte)((v & bmp.gMask) >> shiftG);
+                byte b = (byte)((v & bmp.bMask) >> shiftB);
+                if (bmp.bMask != 0)
+                    a = (byte)((v & bmp.aMask) >> shiftA);
+                data[i] = new Color32(r, g, b, a);
+            }
+        }
+
+
+        private static void Read24BitImage(BinaryReader aReader, BMPImage bmp)
+        {
+            int w = Mathf.Abs(bmp.info.width);
+            int h = Mathf.Abs(bmp.info.height);
+            int rowLength = ((24 * w + 31) / 32) * 4;
+            int count = rowLength * h;
+            int pad = rowLength - w * 3;
+            Color32[] data = bmp.imageData = new Color32[w * h];
+            if (aReader.BaseStream.Position + count > aReader.BaseStream.Length)
+            {
+                Debug.LogError("Unexpected end of file. (Have " + (aReader.BaseStream.Position + count) + " bytes, expected " + aReader.BaseStream.Length + " bytes)");
+                return;
+            }
+            int shiftR = GetShiftCount(bmp.rMask);
+            int shiftG = GetShiftCount(bmp.gMask);
+            int shiftB = GetShiftCount(bmp.bMask);
+            for (int y = 0; y < h; y++)
+            {
+                for (int x = 0; x < w; x++)
+                {
+                    uint v = aReader.ReadByte() | ((uint)aReader.ReadByte() << 8) | ((uint)aReader.ReadByte() << 16);
+                    byte r = (byte)((v & bmp.rMask) >> shiftR);
+                    byte g = (byte)((v & bmp.gMask) >> shiftG);
+                    byte b = (byte)((v & bmp.bMask) >> shiftB);
+                    data[x + y * w] = new Color32(r, g, b, 255);
+                }
+                for (int i = 0; i < pad; i++)
+                    aReader.ReadByte();
+            }
+        }
+
+        private static void Read16BitImage(BinaryReader aReader, BMPImage bmp)
+        {
+            int w = Mathf.Abs(bmp.info.width);
+            int h = Mathf.Abs(bmp.info.height);
+            int rowLength = ((16 * w + 31) / 32) * 4;
+            int count = rowLength * h;
+            int pad = rowLength - w * 2;
+            Color32[] data = bmp.imageData = new Color32[w * h];
+            if (aReader.BaseStream.Position + count > aReader.BaseStream.Length)
+            {
+                Debug.LogError("Unexpected end of file. (Have " + (aReader.BaseStream.Position + count) + " bytes, expected " + aReader.BaseStream.Length + " bytes)");
+                return;
+            }
+            int shiftR = GetShiftCount(bmp.rMask);
+            int shiftG = GetShiftCount(bmp.gMask);
+            int shiftB = GetShiftCount(bmp.bMask);
+            int shiftA = GetShiftCount(bmp.aMask);
+            byte a = 255;
+            for (int y = 0; y < h; y++)
+            {
+                for (int x = 0; x < w; x++)
+                {
+                    uint v = aReader.ReadByte() | ((uint)aReader.ReadByte() << 8);
+                    byte r = (byte)((v & bmp.rMask) >> shiftR);
+                    byte g = (byte)((v & bmp.gMask) >> shiftG);
+                    byte b = (byte)((v & bmp.bMask) >> shiftB);
+                    if (bmp.aMask != 0)
+                        a = (byte)((v & bmp.aMask) >> shiftA);
+                    data[x + y * w] = new Color32(r, g, b, a);
+                }
+                for (int i = 0; i < pad; i++)
+                    aReader.ReadByte();
+            }
+        }
+
+        private static void ReadIndexedImage(BinaryReader aReader, BMPImage bmp)
+        {
+            int w = Mathf.Abs(bmp.info.width);
+            int h = Mathf.Abs(bmp.info.height);
+            int bitCount = bmp.info.nBitsPerPixel;
+            int rowLength = ((bitCount * w + 31) / 32) * 4;
+            int count = rowLength * h;
+            int pad = rowLength - (w * bitCount + 7) / 8;
+            Color32[] data = bmp.imageData = new Color32[w * h];
+            if (aReader.BaseStream.Position + count > aReader.BaseStream.Length)
+            {
+                Debug.LogError("Unexpected end of file. (Have " + (aReader.BaseStream.Position + count) + " bytes, expected " + aReader.BaseStream.Length + " bytes)");
+                return;
+            }
+            BitStreamReader bitReader = new BitStreamReader(aReader);
+            for (int y = 0; y < h; y++)
+            {
+                for (int x = 0; x < w; x++)
+                {
+                    int v = (int)bitReader.ReadBits(bitCount);
+                    if (v >= bmp.palette.Count)
+                    {
+                        Debug.LogError("Indexed bitmap has indices greater than it's color palette");
+                        return;
+                    }
+                    data[x + y * w] = bmp.palette[v];
+                }
+                bitReader.Flush();
+                for (int i = 0; i < pad; i++)
+                    aReader.ReadByte();
+            }
+        }
+        private static void ReadIndexedImageRLE4(BinaryReader aReader, BMPImage bmp)
+        {
+            int w = Mathf.Abs(bmp.info.width);
+            int h = Mathf.Abs(bmp.info.height);
+            Color32[] data = bmp.imageData = new Color32[w * h];
+            int x = 0;
+            int y = 0;
+            int yOffset = 0;
+            while (aReader.BaseStream.Position < aReader.BaseStream.Length - 1)
+            {
+                int count = (int)aReader.ReadByte();
+                byte d = aReader.ReadByte();
+                if (count > 0)
+                {
+                    for (int i = (count / 2); i > 0; i--)
+                    {
+                        data[x++ + yOffset] = bmp.palette[(d >> 4) & 0x0F];
+                        data[x++ + yOffset] = bmp.palette[d & 0x0F];
+                    }
+                    if ((count & 0x01) > 0)
+                    {
+                        data[x++ + yOffset] = bmp.palette[(d >> 4) & 0x0F];
+                    }
+                }
+                else
+                {
+                    if (d == 0)
+                    {
+                        x = 0;
+                        y += 1;
+                        yOffset = y * w;
+                    }
+                    else if (d == 1)
+                    {
+                        break;
+                    }
+                    else if (d == 2)
+                    {
+                        x += aReader.ReadByte();
+                        y += aReader.ReadByte();
+                        yOffset = y * w;
+                    }
+                    else
+                    {
+                        for (int i = (d / 2); i > 0; i--)
+                        {
+                            byte d2 = aReader.ReadByte();
+                            data[x++ + yOffset] = bmp.palette[(d2 >> 4) & 0x0F];
+                            data[x++ + yOffset] = bmp.palette[d2 & 0x0F];
+                        }
+                        if ((d & 0x01) > 0)
+                        {
+                            data[x++ + yOffset] = bmp.palette[(aReader.ReadByte() >> 4) & 0x0F];
+                        }
+                        if ((((d - 1) / 2) & 1) == 0)
+                        {
+                            aReader.ReadByte(); // padding (word alignment)
+                        }
+                    }
+                }
+            }
+        }
+        private static void ReadIndexedImageRLE8(BinaryReader aReader, BMPImage bmp)
+        {
+            int w = Mathf.Abs(bmp.info.width);
+            int h = Mathf.Abs(bmp.info.height);
+            Color32[] data = bmp.imageData = new Color32[w * h];
+            int x = 0;
+            int y = 0;
+            int yOffset = 0;
+            while (aReader.BaseStream.Position < aReader.BaseStream.Length - 1)
+            {
+                int count = (int)aReader.ReadByte();
+                byte d = aReader.ReadByte();
+                if (count > 0)
+                {
+                    for (int i = count; i > 0; i--)
+                    {
+                        data[x++ + yOffset] = bmp.palette[d];
+                    }
+                }
+                else
+                {
+                    if (d == 0)
+                    {
+                        x = 0;
+                        y += 1;
+                        yOffset = y * w;
+                    }
+                    else if (d == 1)
+                    {
+                        break;
+                    }
+                    else if (d == 2)
+                    {
+                        x += aReader.ReadByte();
+                        y += aReader.ReadByte();
+                        yOffset = y * w;
+                    }
+                    else
+                    {
+                        for (int i = d; i > 0; i--)
+                        {
+                            data[x++ + yOffset] = bmp.palette[aReader.ReadByte()];
+                        }
+                        if ((d & 0x01) > 0)
+                        {
+                            aReader.ReadByte(); // padding (word alignment)
+                        }
+                    }
+                }
+            }
+        }
+        private static int GetShiftCount(uint mask)
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                if ((mask & 0x01) > 0)
+                    return i;
+                mask >>= 1;
+            }
+            return -1;
+        }
+        private static uint GetMask(int bitCount)
+        {
+            uint mask = 0;
+            for (int i = 0; i < bitCount; i++)
+            {
+                mask <<= 1;
+                mask |= 0x01;
+            }
+            return mask;
+        }
+        private static bool ReadFileHeader(BinaryReader aReader, ref BMPFileHeader aFileHeader)
+        {
+            aFileHeader.magic = aReader.ReadUInt16();
+            if (aFileHeader.magic != MAGIC)
+                return false;
+            aFileHeader.filesize = aReader.ReadUInt32();
+            aFileHeader.reserved = aReader.ReadUInt32();
+            aFileHeader.offset = aReader.ReadUInt32();
+            return true;
+        }
+        private static bool ReadInfoHeader(BinaryReader aReader, ref BitmapInfoHeader aHeader)
+        {
+            aHeader.size = aReader.ReadUInt32();
+            if (aHeader.size < 40)
+                return false;
+            aHeader.width = aReader.ReadInt32();
+            aHeader.height = aReader.ReadInt32();
+            aHeader.nColorPlanes = aReader.ReadUInt16();
+            aHeader.nBitsPerPixel = aReader.ReadUInt16();
+            aHeader.compressionMethod = (BMPComressionMode)aReader.ReadInt32();
+            aHeader.rawImageSize = aReader.ReadUInt32();
+            aHeader.xPPM = aReader.ReadInt32();
+            aHeader.yPPM = aReader.ReadInt32();
+            aHeader.nPaletteColors = aReader.ReadUInt32();
+            aHeader.nImportantColors = aReader.ReadUInt32();
+            int pad = (int)aHeader.size - 40;
+            if (pad > 0)
+                aReader.ReadBytes(pad);
+            return true;
+        }
+        public static List<Color32> ReadPalette(BinaryReader aReader, BMPImage aBmp, bool aReadAlpha)
+        {
+            uint count = aBmp.info.nPaletteColors;
+            if (count == 0u)
+                count = 1u << aBmp.info.nBitsPerPixel;
+            var palette = new List<Color32>((int)count);
+            for (int i = 0; i < count; i++)
+            {
+                byte b = aReader.ReadByte();
+                byte g = aReader.ReadByte();
+                byte r = aReader.ReadByte();
+                byte a = aReader.ReadByte();
+                if (!aReadAlpha)
+                    a = 255;
+                palette.Add(new Color32(r, g, b, a));
+            }
+            return palette;
+        }
+
+    }
+    public class BitStreamReader
+    {
+        BinaryReader m_Reader;
+        byte m_Data = 0;
+        int m_Bits = 0;
+
+        public BitStreamReader(BinaryReader aReader)
+        {
+            m_Reader = aReader;
+        }
+        public BitStreamReader(Stream aStream) : this(new BinaryReader(aStream)) { }
+
+        public byte ReadBit()
+        {
+            if (m_Bits <= 0)
+            {
+                m_Data = m_Reader.ReadByte();
+                m_Bits = 8;
+            }
+            return (byte)((m_Data >> --m_Bits) & 1);
+        }
+
+        public ulong ReadBits(int aCount)
+        {
+            ulong val = 0UL;
+            if (aCount <= 0 || aCount > 32)
+                throw new System.ArgumentOutOfRangeException("aCount", "aCount must be between 1 and 32 inclusive");
+            for (int i = aCount - 1; i >= 0; i--)
+                val |= ((ulong)ReadBit() << i);
+            return val;
+        }
+        public void Flush()
+        {
+            m_Data = 0;
+            m_Bits = 0;
+        }
+    }
+}

--- a/Boardless/Assets/OBJImport/TextureLoader/BMPLoader.cs.meta
+++ b/Boardless/Assets/OBJImport/TextureLoader/BMPLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27d41db6b761bbb4a989566820e47137
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/TextureLoader/BinaryExtensions.cs
+++ b/Boardless/Assets/OBJImport/TextureLoader/BinaryExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace Dummiesman
+{
+    public static class BinaryExtensions
+    {
+        public static Color32 ReadColor32RGBR(this BinaryReader r)
+        {
+            var bytes = r.ReadBytes(4);
+            return new Color32(bytes[0], bytes[1], bytes[2], 255);
+        }
+
+        public static Color32 ReadColor32RGBA(this BinaryReader r)
+        {
+            var bytes = r.ReadBytes(4);
+            return new Color32(bytes[0], bytes[1], bytes[2], bytes[3]);
+        }
+
+        public static Color32 ReadColor32RGB(this BinaryReader r)
+        {
+            var bytes = r.ReadBytes(3);
+            return new Color32(bytes[0], bytes[1], bytes[2], 255);
+        }
+
+        public static Color32 ReadColor32BGR(this BinaryReader r)
+        {
+            var bytes = r.ReadBytes(3);
+            return new Color32(bytes[2], bytes[1], bytes[0], 255);
+        }
+    }
+}

--- a/Boardless/Assets/OBJImport/TextureLoader/BinaryExtensions.cs.meta
+++ b/Boardless/Assets/OBJImport/TextureLoader/BinaryExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b61b2ce827ad8842a6812f45f25aaa1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/TextureLoader/ColorExtensions.cs
+++ b/Boardless/Assets/OBJImport/TextureLoader/ColorExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Dummiesman.Extensions
+{
+    public static class ColorExtensions
+    {
+        public static Color FlipRB(this Color color)
+        {
+            return new Color(color.b, color.g, color.r, color.a);
+        }
+
+        public static Color32 FlipRB(this Color32 color)
+        {
+            return new Color32(color.b, color.g, color.r, color.a);
+        }
+    }
+}

--- a/Boardless/Assets/OBJImport/TextureLoader/ColorExtensions.cs.meta
+++ b/Boardless/Assets/OBJImport/TextureLoader/ColorExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8034e4bf991d15a4b88970b534ce4a0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/TextureLoader/DDSLoader.cs
+++ b/Boardless/Assets/OBJImport/TextureLoader/DDSLoader.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+namespace Dummiesman
+{
+    public static class DDSLoader
+    {
+        public static Texture2D Load(Stream ddsStream)
+        {
+            byte[] buffer = new byte[ddsStream.Length];
+            ddsStream.Read(buffer, 0, (int)ddsStream.Length);
+            return Load(buffer);
+        }
+
+        public static Texture2D Load(string ddsPath)
+        {
+           return Load(File.ReadAllBytes(ddsPath));
+        }
+
+        public static Texture2D Load(byte[] ddsBytes)
+        {
+            try
+            {
+
+                //do size check
+                byte ddsSizeCheck = ddsBytes[4];
+                if (ddsSizeCheck != 124)
+                    throw new System.Exception("Invalid DDS header. Structure length is incrrrect."); //this header byte should be 124 for DDS image files
+
+                //verify we have a readable tex
+                byte DXTType = ddsBytes[87];
+                if (DXTType != 49 && DXTType != 53)
+                    throw new System.Exception("Cannot load DDS due to an unsupported pixel format. Needs to be DXT1 or DXT5.");
+
+                int height = ddsBytes[13] * 256 + ddsBytes[12];
+                int width = ddsBytes[17] * 256 + ddsBytes[16];
+                bool mipmaps = ddsBytes[28] > 0;
+                TextureFormat textureFormat = DXTType == 49 ? TextureFormat.DXT1 : TextureFormat.DXT5;
+
+                int DDS_HEADER_SIZE = 128;
+                byte[] dxtBytes = new byte[ddsBytes.Length - DDS_HEADER_SIZE];
+                Buffer.BlockCopy(ddsBytes, DDS_HEADER_SIZE, dxtBytes, 0, ddsBytes.Length - DDS_HEADER_SIZE);
+
+                Texture2D texture = new Texture2D(width, height, textureFormat, mipmaps);
+                texture.LoadRawTextureData(dxtBytes);
+                texture.Apply();
+
+                return texture;
+            }
+            catch (System.Exception ex)
+            {
+                throw new Exception("An error occured while loading DirectDraw Surface: " + ex.Message);
+            }
+        }
+    }
+}

--- a/Boardless/Assets/OBJImport/TextureLoader/DDSLoader.cs.meta
+++ b/Boardless/Assets/OBJImport/TextureLoader/DDSLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f9e65e68712e0f41aae633289ab739e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/TextureLoader/ImageLoader.cs
+++ b/Boardless/Assets/OBJImport/TextureLoader/ImageLoader.cs
@@ -1,0 +1,158 @@
+﻿/*
+ * Created by Dummiesman 2013-2019
+ * Thanks to mikezila for improving the initial TGA loading code
+*/
+
+using System;
+using UnityEngine;
+using System.Collections;
+using System.IO;
+using B83.Image.BMP;
+
+namespace Dummiesman
+{
+    public class ImageLoader
+    {
+        /// <summary>
+        /// Converts a DirectX normal map to Unitys expected format
+        /// </summary>
+        /// <param name="tex">Texture to convert</param>
+        public static void SetNormalMap(ref Texture2D tex)
+        {
+            Color[] pixels = tex.GetPixels();
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                Color temp = pixels[i];
+                temp.r = pixels[i].g;
+                temp.a = pixels[i].r;
+                pixels[i] = temp;
+            }
+            tex.SetPixels(pixels);
+            tex.Apply(true);
+        }
+
+        public enum TextureFormat
+        {
+            DDS,
+            TGA,
+            BMP,
+            PNG,
+            JPG,
+            CRN
+        }
+
+
+        /// <summary>
+        /// Loads a texture from a stream
+        /// </summary>
+        /// <param name="stream">The stream</param>
+        /// <param name="format">The format **NOT UNITYENGINE.TEXTUREFORMAT**</param>
+        /// <returns></returns>
+        public static Texture2D LoadTexture(Stream stream, TextureFormat format)
+        {
+            if (format == TextureFormat.BMP)
+            {
+                return new BMPLoader().LoadBMP(stream).ToTexture2D();
+            }
+            else if (format == TextureFormat.DDS)
+            {
+                return DDSLoader.Load(stream);
+            }
+            else if (format == TextureFormat.JPG || format == TextureFormat.PNG)
+            {
+                byte[] buffer = new byte[stream.Length];
+                stream.Read(buffer, 0, (int)stream.Length);
+
+                Texture2D texture = new Texture2D(1, 1);
+                texture.LoadImage(buffer);
+                return texture;
+            }
+            else if (format == TextureFormat.TGA)
+            {
+                return TGALoader.Load(stream);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+      
+        /// <summary>
+        /// Loads a texture from a file
+        /// </summary>
+        /// <param name="fn"></param>
+        /// <param name="normalMap"></param>
+        /// <returns></returns>
+        public static Texture2D LoadTexture(string fn)
+        {
+            if (!File.Exists(fn))
+                return null;
+
+            var textureBytes = File.ReadAllBytes(fn);
+            string ext = Path.GetExtension(fn).ToLower();
+            string name = Path.GetFileName(fn);
+            Texture2D returnTex = null;
+
+            switch (ext)
+            {
+                case ".png":
+                case ".jpg":
+                case ".jpeg":
+                    returnTex = new Texture2D(1, 1);
+                    returnTex.LoadImage(textureBytes);
+                    break;
+                case ".dds":
+                    returnTex = DDSLoader.Load(textureBytes);
+                    break;
+                case ".tga":
+                    returnTex = TGALoader.Load(textureBytes);
+                    break;
+                case ".bmp":
+                    returnTex = new BMPLoader().LoadBMP(textureBytes).ToTexture2D();
+                    break;
+                case ".crn":
+                    byte[] crnBytes = textureBytes;
+                    ushort crnWidth = System.BitConverter.ToUInt16(new byte[2] { crnBytes[13], crnBytes[12] }, 0);
+                    ushort crnHeight = System.BitConverter.ToUInt16(new byte[2] { crnBytes[15], crnBytes[14] }, 0);
+                    byte crnFormatByte = crnBytes[18];
+
+                    var crnTextureFormat = UnityEngine.TextureFormat.RGB24;
+                    if (crnFormatByte == 0)
+                    {
+                        crnTextureFormat = UnityEngine.TextureFormat.DXT1Crunched;
+                    }else if(crnFormatByte == 2)
+                    {
+                        crnTextureFormat = UnityEngine.TextureFormat.DXT5Crunched;
+                    }
+                    else if(crnFormatByte == 12)
+                    {
+                        crnTextureFormat = UnityEngine.TextureFormat.ETC2_RGBA8Crunched;
+                    }
+                    else
+                    {
+                        Debug.LogError("Could not load crunched texture " + name + " because its format is not supported (" + crnFormatByte + "): " + fn);
+                        break;
+                    }
+
+                    returnTex = new Texture2D(crnWidth, crnHeight, crnTextureFormat, true);
+                    returnTex.LoadRawTextureData(crnBytes);
+                    returnTex.Apply(true);
+
+                    break;
+                default:
+                    Debug.LogError("Could not load texture " + name + " because its format is not supported : " + fn);
+                    break;
+            }
+            
+            if (returnTex != null)
+            {
+                returnTex = ImageLoaderHelper.VerifyFormat(returnTex);
+                returnTex.name = Path.GetFileNameWithoutExtension(fn);
+            }                                           
+
+            return returnTex;
+        }
+
+    }
+}

--- a/Boardless/Assets/OBJImport/TextureLoader/ImageLoader.cs.meta
+++ b/Boardless/Assets/OBJImport/TextureLoader/ImageLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 075edea996ccdd6489ad5e1197dd3f67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/TextureLoader/ImageLoaderHelper.cs
+++ b/Boardless/Assets/OBJImport/TextureLoader/ImageLoaderHelper.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace Dummiesman
+{
+    public class ImageLoaderHelper
+    {
+        /// <summary>
+        /// Verifies that a 32bpp texture is actuall 32bpp
+        /// </summary>
+        /// <returns>The verified texture</returns>
+        public static Texture2D VerifyFormat(Texture2D tex)
+        {
+            if (tex.format != UnityEngine.TextureFormat.ARGB32 && tex.format != UnityEngine.TextureFormat.RGBA32 && tex.format != UnityEngine.TextureFormat.DXT5)
+                return tex;
+
+            //get pixels
+            var pixels = tex.GetPixels32();
+            bool validFormat = false;
+
+            //check each pixel alpha
+            foreach(var px in pixels)
+            {
+                if(px.a < 255)
+                {
+                    validFormat = true;
+                    break;
+                }
+            }
+
+            //if it's not a valid format return a new 24bpp image
+            if (!validFormat)
+            {
+                var tex24 = new Texture2D(tex.width, tex.height, UnityEngine.TextureFormat.RGB24, tex.mipmapCount > 0);
+                tex24.SetPixels32(pixels);
+                tex24.Apply(true);
+                return tex24;
+            }
+
+            //return original if valid
+            return tex;
+        }
+
+        /// <summary>
+        /// A cluster for creating arrays of Unity Color 
+        /// </summary>
+        /// <param name="fillArray"></param>
+        /// <param name="pixelData"></param>
+        /// <param name="bytesPerPixel"></param>
+        /// <param name="bgra"></param>
+        public static void FillPixelArray(Color32[] fillArray, byte[] pixelData, int bytesPerPixel, bool bgra = false)
+        {
+            //special case for TGA :(
+            if (bgra)
+            {
+                if (bytesPerPixel == 4)
+                {
+                    for (int i = 0; i < fillArray.Length; i++)
+                    {
+                        int bi = i * bytesPerPixel;
+                        fillArray[i] = new Color32(pixelData[bi + 2], pixelData[bi + 1], pixelData[bi], pixelData[bi + 3]);
+                    }
+                }
+                else
+                {
+                    //24 bit BGR to Color32 (RGBA)
+                    //this is faster than safe code
+                    for (int i = 0; i < fillArray.Length; i++)
+                    {
+                        fillArray[i].r = pixelData[(i * 3) + 2];
+                        fillArray[i].g = pixelData[(i * 3) + 1];
+                        fillArray[i].b = pixelData[(i * 3) + 0];
+                    }
+                }
+            }
+            else
+            {
+                if (bytesPerPixel == 4)
+                {
+                    for (int i = 0; i < fillArray.Length; i++)
+                    {
+                        fillArray[i].r = pixelData[i * 4];
+                        fillArray[i].g = pixelData[(i * 4) + 1];
+                        fillArray[i].b = pixelData[(i * 4) + 2];
+                        fillArray[i].a = pixelData[(i * 4) + 3];
+                    }
+                }
+                else
+                {
+                    //with RGB we can't! :(
+                    int bi = 0;
+                    for (int i = 0; i < fillArray.Length; i++)
+                    {
+                        fillArray[i].r = pixelData[bi++];
+                        fillArray[i].g = pixelData[bi++];
+                        fillArray[i].b = pixelData[bi++];
+                        fillArray[i].a = 255;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Boardless/Assets/OBJImport/TextureLoader/ImageLoaderHelper.cs.meta
+++ b/Boardless/Assets/OBJImport/TextureLoader/ImageLoaderHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8658e22fc9a3c94ab5d8c6460812b69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/TextureLoader/ImageUtils.cs
+++ b/Boardless/Assets/OBJImport/TextureLoader/ImageUtils.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Dummiesman
+{
+    public static class ImageUtils
+    {
+        public static Texture2D ConvertToNormalMap(Texture2D tex)
+        {
+            Texture2D returnTex = tex;
+            if(tex.format != TextureFormat.RGBA32 && tex.format != TextureFormat.ARGB32)
+            {
+                returnTex = new Texture2D(tex.width, tex.height, TextureFormat.RGBA32, true);
+            }
+
+            Color[] pixels = tex.GetPixels();
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                Color temp = pixels[i];
+                temp.a = pixels[i].r;
+                temp.r = 0f;
+                temp.g = pixels[i].g;
+                temp.b = 0f;
+                pixels[i] = temp;
+            }
+            
+            returnTex.SetPixels(pixels);
+            returnTex.Apply(true);
+            return returnTex;
+        }
+        
+    }
+}
+

--- a/Boardless/Assets/OBJImport/TextureLoader/ImageUtils.cs.meta
+++ b/Boardless/Assets/OBJImport/TextureLoader/ImageUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 594f0c9c36902bc4aa1e6fd12ae28fd0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/OBJImport/TextureLoader/TGALoader.cs
+++ b/Boardless/Assets/OBJImport/TextureLoader/TGALoader.cs
@@ -1,0 +1,127 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.IO;
+using System;
+using Dummiesman.Extensions;
+using System.Runtime.InteropServices;
+
+namespace Dummiesman
+{
+    public class TGALoader
+    {
+        private static int GetBits(byte b, int offset, int count)
+        {
+            return (b >> offset) & ((1 << count) - 1);
+        }
+
+        private static Color32[] LoadRawTGAData(BinaryReader r, int bitDepth, int width, int height)
+        {
+            Color32[] pulledColors = new Color32[width * height];
+
+            byte[] colorData = r.ReadBytes(width * height * (bitDepth / 8));
+            ImageLoaderHelper.FillPixelArray(pulledColors, colorData, (bitDepth / 8), true);
+
+            return pulledColors;
+        }
+
+        private static Color32[] LoadRLETGAData(BinaryReader r, int bitDepth, int width, int height)
+        {
+            Color32[] pulledColors = new Color32[width * height];
+            int pulledColorCount = 0;
+
+            while (pulledColorCount < pulledColors.Length)
+            {
+                byte rlePacket = r.ReadByte();
+                int RLEPacketType = GetBits(rlePacket, 7, 1);
+                int RLEPixelCount = GetBits(rlePacket, 0, 7) + 1;
+
+
+                if (RLEPacketType == 0)
+                {
+                    //raw packet
+                    for (int i = 0; i < RLEPixelCount; i++)
+                    {
+                        var color = (bitDepth == 32) ? r.ReadColor32RGBA().FlipRB() : r.ReadColor32RGB().FlipRB();
+                        pulledColors[i + pulledColorCount] = color;
+                    }
+
+                }
+                else
+                {
+                    //rle packet
+                    var color = (bitDepth == 32) ? r.ReadColor32RGBA().FlipRB() : r.ReadColor32RGB().FlipRB();
+
+                    for (int i = 0; i < RLEPixelCount; i++)
+                    {
+                        pulledColors[i + pulledColorCount] = color;
+                    }
+                }
+
+                pulledColorCount += RLEPixelCount;
+            }
+
+            return pulledColors;
+        }
+
+        public static Texture2D Load(string fileName)
+        {
+            using (var imageFile = File.OpenRead(fileName))
+            {
+                return Load(imageFile);
+            }
+        }
+
+        public static Texture2D Load(byte[] bytes)
+        {
+            using (var ms = new MemoryStream(bytes))
+            {
+                return Load(ms);
+            }
+        }
+
+        public static Texture2D Load(Stream TGAStream)
+        {
+
+            using (BinaryReader r = new BinaryReader(TGAStream))
+            {
+                // Skip some header info we don't care about.
+                r.BaseStream.Seek(2, SeekOrigin.Begin);
+
+                byte imageType = r.ReadByte();
+                if (imageType != 10 && imageType != 2)
+                {
+                    Debug.LogError($"Unsupported targa image type. ({imageType})");
+                    return null;
+                }
+
+                //Skip right to some more data we need
+                r.BaseStream.Seek(12, SeekOrigin.Begin);
+
+                short width = r.ReadInt16();
+                short height = r.ReadInt16();
+                int bitDepth = r.ReadByte();
+
+                if (bitDepth < 24)
+                    throw new Exception("Tried to load TGA with unsupported bit depth");
+
+                // Skip a byte of header information we don't care about.
+                r.BaseStream.Seek(1, SeekOrigin.Current);
+
+                Texture2D tex = new Texture2D(width, height, (bitDepth == 24) ? TextureFormat.RGB24 :  TextureFormat.ARGB32, true);
+                if (imageType == 2)
+                {
+                    tex.SetPixels32(LoadRawTGAData(r, bitDepth, width, height));
+                }
+                else
+                {
+                    tex.SetPixels32(LoadRLETGAData(r, bitDepth, width, height));
+                }
+
+                tex.Apply();
+                return tex;
+
+            }
+        }
+    }
+}

--- a/Boardless/Assets/OBJImport/TextureLoader/TGALoader.cs.meta
+++ b/Boardless/Assets/OBJImport/TextureLoader/TGALoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b682979498a095418396a690d23c0b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/Resources/ObjLoading.mat
+++ b/Boardless/Assets/Resources/ObjLoading.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ObjLoading
+  m_Shader: {fileID: 45, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+  m_BuildTextureStacks: []

--- a/Boardless/Assets/Resources/ObjLoading.mat.meta
+++ b/Boardless/Assets/Resources/ObjLoading.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7f3e5e56807d0434a8ec59b3e01bd585
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/Resources/Transparent.mat
+++ b/Boardless/Assets/Resources/Transparent.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Transparent
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Boardless/Assets/Resources/Transparent.mat.meta
+++ b/Boardless/Assets/Resources/Transparent.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1c1ba00dc9307459ea31f449409218ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boardless/Assets/Scenes/FirebaseServicesTest.unity
+++ b/Boardless/Assets/Scenes/FirebaseServicesTest.unity
@@ -1607,4 +1607,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Firebase: {fileID: 443720832}
   SpawnLocation: {x: 0, y: 2, z: 0}
-  TextContainerPrefab: {fileID: 6915144195276213187, guid: a07f621bd631b4868b7d9a82ef0fd25b, type: 3}
+  TextContainerPrefab: {fileID: 0}

--- a/Boardless/Assets/Scripts/FirebaseFilesDropdown.cs
+++ b/Boardless/Assets/Scripts/FirebaseFilesDropdown.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using Firebase.Firestore;
 using Firebase.Storage;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.XR.Interaction.Toolkit;
 
 public class FirebaseFilesDropdown : MonoBehaviour
 {
@@ -13,8 +16,9 @@ public class FirebaseFilesDropdown : MonoBehaviour
     public GameObject TextContainerPrefab;
 
     // document id -> file
-    private SortedList<string, File> _documents = new SortedList<string, File>();
-    private struct File {
+    private SortedList<string, FirebaseFile> _documents = new SortedList<string, FirebaseFile>();
+    private struct FirebaseFile
+    {
         public string Name;
         public string RefOrNull;
         public string ContentOrNull;
@@ -32,6 +36,11 @@ public class FirebaseFilesDropdown : MonoBehaviour
         {
             OnDropdownValueChange(_dropDown);
         });
+        string directoryPath = LocalDirectory();
+        if (!Directory.Exists(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
     }
 
     private void OnRoomDocumentsChange(QuerySnapshot snapshot)
@@ -40,7 +49,7 @@ public class FirebaseFilesDropdown : MonoBehaviour
         {
             string id = change.Document.Id;
             int index;
-            File file;
+            FirebaseFile file;
             switch (change.ChangeType)
             {
                 case DocumentChange.Type.Added:
@@ -48,6 +57,8 @@ public class FirebaseFilesDropdown : MonoBehaviour
                     index = _documents.Keys.IndexOf(id) + 1;
                     file = FileForDocument(change.Document);
                     _dropDown.options.Insert(index, new Dropdown.OptionData { text = file.Name });
+                    // need to aggreesively download for 3D object loading
+                    DownloadIfFileRef(file, false);
                     break;
                 case DocumentChange.Type.Modified:
                     file = FileForDocument(change.Document);
@@ -58,27 +69,75 @@ public class FirebaseFilesDropdown : MonoBehaviour
                         _dropDown.options.RemoveAt(index);
                         _dropDown.options.Insert(index, new Dropdown.OptionData { text = file.Name });
                     }
+                    DownloadIfFileRef(file, true);
                     break;
                 case DocumentChange.Type.Removed:
                     index = _documents.Keys.IndexOf(id) + 1;
                     _dropDown.options.RemoveAt(index);
                     _documents.Remove(id);
+                    // we cannot delete file because it can still be in use
                     break;
             }
         }
     }
 
-    private File FileForDocument(DocumentSnapshot document)
+    private FirebaseFile FileForDocument(DocumentSnapshot document)
     {
         string refOrNull, contentOrNull;
         document.TryGetValue("ref", out refOrNull);
         document.TryGetValue("content", out contentOrNull);
-        return new File
+        return new FirebaseFile
         {
             Name = FirebaseServices.GetDisplayName(document),
             RefOrNull = refOrNull,
             ContentOrNull = contentOrNull,
         };
+    }
+
+    private string LocalDirectory()
+    {
+        return Path.Combine(Application.persistentDataPath, FirebaseServices.Room);
+    }
+
+    private string LocalPathForFile(FirebaseFile file)
+    {
+        if (file.RefOrNull == null)
+        {
+            return null;
+        }
+        else
+        {
+            return Path.Combine(LocalDirectory(), file.RefOrNull);
+        }
+    }
+
+    private void DownloadIfFileRef(FirebaseFile file, bool downloadIfExists)
+    {
+
+        string fullName = LocalPathForFile(file);
+        if (fullName == null)
+        {
+            return;
+        }
+        if (File.Exists(fullName) && !downloadIfExists)
+        {
+            Debug.Log($"File exists at {fullName} and no download required.");
+            return;
+        }
+        Firebase.RefForDownload(file.RefOrNull)
+            // Firebase expects starting with file://
+            .GetFileAsync(new Uri(fullName).AbsoluteUri)
+            .ContinueWith(task =>
+            {
+                if (!task.IsFaulted && !task.IsCanceled)
+                {
+                    Debug.Log($"File download OK: {fullName}.");
+                }
+                else
+                {
+                    Debug.Log($"File download NO: {fullName}.");
+                }
+            });
     }
 
     private void OnDropdownValueChange(Dropdown dropdown)
@@ -90,7 +149,7 @@ public class FirebaseFilesDropdown : MonoBehaviour
             return;
         }
         int fileIndex = index - 1;
-        File file = _documents[_documents.Keys[fileIndex]];
+        FirebaseFile file = _documents[_documents.Keys[fileIndex]];
         if (file.RefOrNull != null)
         {
             InstantiateFile(file);
@@ -105,22 +164,106 @@ public class FirebaseFilesDropdown : MonoBehaviour
 
     private void InstantiateTextDisplay(string text)
     {
+        if (TextContainerPrefab == null)
+        {
+            Debug.LogError("FirebaseFileDropdown No TextContainerPrefab");
+            Debug.Log(text);
+            return;
+        }
         GameObject textContainer = Instantiate(TextContainerPrefab, SpawnLocation, Quaternion.identity);
         textContainer.GetComponentInChildren<TextMesh>().text = text;
     }
 
-    private void InstantiateFile(File file)
+    private void InstantiateFile(FirebaseFile file)
     {
-        // FIXME: implement handling per type.
-        // Please arrange file suffix alphabetically to reduce merge conflicts.
-        StorageReference storageRef = Firebase.RefForDownload(file.RefOrNull);
-
-        if (file.Name.EndsWith("*.png"))
+        string path = LocalPathForFile(file);
+        if (path == null)
         {
-            InstantiateTextDisplay($"Can't display {file.Name}");
+            Debug.LogError($"Trying to instantiate ${file.Name} without file in storage");
             return;
         }
+        if (!File.Exists(path))
+        {
+            Debug.LogWarning($"{file.Name} isn't downloaded to ${path}");
+            InstantiateTextDisplay($"{file.Name} is not available at this time");
+            return;
+        }
+        string extension = Path.GetExtension(path).ToLower();
+        // FIXME: implement handling per type.
+        // Please arrange file extensions alphabetically to reduce merge conflicts.
+        Debug.Log($"Trying to display {file.Name} at {path} with extension {extension}");
+        switch (extension)
+        {
+            case ".obj":
+                GameObject newObject = new Dummiesman.OBJLoader().Load(path);
+                if (newObject == null) break;
+                newObject.transform.position = SpawnLocation;
 
+                Vector3 size = GetObjBounds(newObject).size;
+                Debug.Log(size);
+
+                if (size == Vector3.zero)
+                {
+                    // not working
+                    break;
+                }
+
+                BoxCollider collider = newObject.AddComponent<BoxCollider>();
+                collider.size = size;
+
+                // scale to about 0.5 so not too big not to small
+                // https://stackoverflow.com/a/31670874
+                float minSize = Math.Min(size.x, Math.Min(size.y, size.z));
+                Vector3 newScale = newObject.transform.localScale * (0.5f / minSize);
+                // box collider want positive, fine
+                newScale.x = Math.Abs(newScale.x);
+                newScale.y = Math.Abs(newScale.y);
+                newScale.z = Math.Abs(newScale.z);
+
+                newObject.transform.localScale = newScale;
+                Debug.Log(newScale);
+
+                AddXRInteractions(newObject);
+
+                return;
+            default:
+                break;
+        }
         InstantiateTextDisplay($"Can't display {file.Name}");
+        return;
+    }
+
+    // https://answers.unity.com/questions/208645/true-scale-of-a-visible-gameobject-with-many-child.html
+    private Bounds GetObjBounds(GameObject newObject)
+    {
+        Bounds bounds = new Bounds(newObject.transform.position, Vector3.zero);
+        foreach (Renderer r in newObject.GetComponentsInChildren<Renderer>())
+        {
+            bounds.Encapsulate(r.bounds);
+        }
+        return bounds;
+    }
+
+    private void AddXRInteractions(GameObject newObject)
+    {
+        MoveWithController moveWithController = newObject.AddComponent<MoveWithController>();
+        moveWithController.InputScale = 0.3f;
+        ChangeScale changeScale = newObject.AddComponent<ChangeScale>();
+        changeScale.InputScale = 0.3f;
+
+        XRSimpleInteractable interactable = newObject.AddComponent<XRSimpleInteractable>();
+        interactable.selectMode = InteractableSelectMode.Single;
+        interactable.selectEntered.AddListener((arg0) =>
+        {
+            moveWithController.ActivateMove();
+            changeScale.ActivateScaling();
+        });
+        interactable.selectExited.AddListener((arg0) =>
+        {
+            moveWithController.DeactivateMove();
+            changeScale.DeactivatScaling();
+        });
+
+        // FIXME: implement sync over Photon
     }
 }

--- a/Boardless/ProjectSettings/ProjectSettings.asset
+++ b/Boardless/ProjectSettings/ProjectSettings.asset
@@ -328,7 +328,7 @@ PlayerSettings:
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
   ForceInternetPermission: 0
-  ForceSDCardPermission: 0
+  ForceSDCardPermission: 1
   CreateWallpaper: 0
   APKExpansionFiles: 0
   keepLoadedShadersAlive: 0


### PR DESCRIPTION
Please merge #26 first

## Changelog

- Added file types
   - `.obj` (with `.mtl`) files to import 3D objects with textures
   - `.png` (with or without transparency), `.jpg`, and `.jpeg` for normal pictures
- The added objects can be moved and scaled like the primitives

## Known Issues

- States are not synced over the network as we can't bundle user uploaded files in `Resources` as required by Photon

## Future Directions

- GLTF with https://github.com/KhronosGroup/UnityGLTF or https://github.com/Siccity/GLTFUtility
- FBX with https://forum.unity.com/threads/fbx-mesh-importer-at-runtime.230787/ or https://archern9.github.io/posts/ingesting-asset-bundles-at-runtime/
- Purchase fancy package for more 3D model types https://assetstore.unity.com/packages/tools/modeling/trilib-2-model-loading-package-157548

## Screenshots

|image|model|
|--|--|
|![image with or without transparency](https://user-images.githubusercontent.com/10842684/156251709-cc85222d-856a-4a7d-bfd4-7944fbdf8336.jpg)|![3D objects and scaling](https://user-images.githubusercontent.com/10842684/156251767-f0dedf36-d093-4161-bb04-329393c5bff0.jpg)
